### PR TITLE
Hotfix: Fix check in hasDebugMode function

### DIFF
--- a/src/AbstractApiValidationTrait.php
+++ b/src/AbstractApiValidationTrait.php
@@ -229,8 +229,7 @@ trait AbstractApiValidationTrait
 
     private function _hasDebugMode()
     {
-        $value = is_laravel() ? (strtolower(strval(config('joskoomen-abstractapi.debug'))) === 'true') : (strtolower(strval(env('JOSKOOMEN_ABSTRACT_API_DEBUG'))) === 'true');
-        return boolval($value);
+        return is_laravel() ? boolval(config('joskoomen-abstractapi.debug')) : boolval(env('JOSKOOMEN_ABSTRACT_API_DEBUG'));
     }
 
     private function _isEncodingEnabled()


### PR DESCRIPTION
When the JOSKOOMEN_ABSTRACT_API_DEBUG variable in environment is set as boolean, the strval method converts this to "1", so === 'true' check fails.

Reset it to boolval function, so it returns true / false based on the value set.